### PR TITLE
Enable NuGet package publish into GitHub feed

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,5 +24,5 @@ jobs:
     - name: Add GitHub package source
       run: dotnet nuget add source https://nuget.pkg.github.com/pakrym/index.json --name "github" --username NotUsed --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text
     - name: Publish NuGet packages
-      run: dotnet nuget push nuget\*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source "github" --skip-duplicate --no-symbols true
+      run: dotnet nuget push nuget/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source "github" --skip-duplicate --no-symbols true
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,6 +19,8 @@ jobs:
       run: dotnet build src
     - name: Test
       run: dotnet test src --no-build --verbosity normal
+    - name: Pack
+      run: dotnet pack scr --no-build --output nuget
     - name: Add GitHub package source
       run: dotnet nuget add source https://nuget.pkg.github.com/pakrym/index.json --name "github" --username NotUsed --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text
     - name: Publish NuGet packages

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Test
       run: dotnet test src --no-build --verbosity normal
     - name: Add GitHub package source
-      run: dotnet nuget add source https://nuget.pkg.github.com/pakrym/index.json --name "github" --username NotUsed --password ${{ secrets.GITHUB_TOKEN }}
+      run: dotnet nuget add source https://nuget.pkg.github.com/pakrym/index.json --name "github" --username NotUsed --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text
     - name: Publish NuGet packages
       run: dotnet nuget push nuget\*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source "github" --skip-duplicate --no-symbols true
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Test
       run: dotnet test src --no-build --verbosity normal
     - name: Pack
-      run: dotnet pack scr --no-build --output nuget
+      run: dotnet pack src --no-build --output nuget
     - name: Add GitHub package source
       run: dotnet nuget add source https://nuget.pkg.github.com/pakrym/index.json --name "github" --username NotUsed --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text
     - name: Publish NuGet packages

--- a/src/Jab/Jab.csproj
+++ b/src/Jab/Jab.csproj
@@ -4,8 +4,10 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
-        <Version>0.0.1-beta.1</Version>    
+        <GITHUB_RUN_ID Condition="'$(GITHUB_RUN_ID)' == ''" >1</GITHUB_RUN_ID>
+        <Version>0.0.1-beta.$(GITHUB_RUN_ID)</Version>    
         <IncludeBuildOutput>false</IncludeBuildOutput> <!-- Do not include the generator as a lib dependency -->
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
     </PropertyGroup>
 
     <ItemGroup>
@@ -16,6 +18,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
         <TfmSpecificPackageFile Include="Attributes.cs" PackagePath="contentFiles\cs\netstandard2.0\" BuildAction="Compile" />
     </ItemGroup>
     


### PR DESCRIPTION
PR contains multiple small changes to enable publish:
1. add `--store-password-in-clear-text` when adding the feed since encryption does not work on ubuntu, it should be safe since NuGet.Config not available for users.
2. Adds build time dependency on `Microsoft.SourceLink.GitHub` to provide `RepositoryUrl` (and not hardcode it), since it's required to push package.
3. Adds `GITHUB_RUN_ID` (or `1` if you are building not on GitHub actions) to version, which should be unique for each run and provide a unique version on each publish

A successful test run here https://github.com/AndreyTretyak/jab/runs/1609883492?check_suite_focus=true
And package published https://github.com/AndreyTretyak/jab/packages/552191