### PR TITLE
Don't invoke MSBuild for collectioning Jab.Roslyn3

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Test
       run: dotnet test src --no-build --verbosity normal
     - name: Pack
-      run: dotnet pack src --output nuget /p:ReleaseVersion=${{ github.event.inputs.ReleaseVersion }} /bl:"nuget/pack.binlog"
+      run: dotnet pack src --no-build --output nuget /p:ReleaseVersion=${{ github.event.inputs.ReleaseVersion }} /bl:"nuget/pack.binlog"
     - name: Get package version
       shell: pwsh
       id: vars

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Test
       run: dotnet test src --no-build --verbosity normal
     - name: Pack
-      run: dotnet pack src --no-build --output nuget /p:ReleaseVersion=${{ github.event.inputs.ReleaseVersion }}
+      run: dotnet pack src --no-build --output nuget /p:ReleaseVersion=${{ github.event.inputs.ReleaseVersion }} /bl:"nuget/pack.binlog"
     - name: Get package version
       shell: pwsh
       id: vars

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Test
       run: dotnet test src --no-build --verbosity normal
     - name: Pack
-      run: dotnet pack src --no-build --output nuget /p:ReleaseVersion=${{ github.event.inputs.ReleaseVersion }} /bl:"nuget/pack.binlog"
+      run: dotnet pack src --output nuget /p:ReleaseVersion=${{ github.event.inputs.ReleaseVersion }} /bl:"nuget/pack.binlog"
     - name: Get package version
       shell: pwsh
       id: vars

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Test
       run: dotnet test src --no-build --verbosity normal
     - name: Pack
-      run: dotnet pack src --no-build --output nuget /p:ReleaseVersion=${{ github.event.inputs.ReleaseVersion }} /bl:"nuget/pack.binlog"
+      run: dotnet pack src --no-build --output nuget /p:ReleaseVersion=${{ github.event.inputs.ReleaseVersion }}
     - name: Get package version
       shell: pwsh
       id: vars

--- a/src/Jab/Jab.csproj
+++ b/src/Jab/Jab.csproj
@@ -9,6 +9,8 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+        <!-- Make sure that ResolveProjectReferences target runs before pack to include Jab for roslyn3. -->
+        <BeforePack>$(BeforePack);ResolveProjectReferences</BeforePack>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 

--- a/src/Jab/Jab.csproj
+++ b/src/Jab/Jab.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
@@ -13,7 +13,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="../Jab.Roslyn3/Jab.Roslyn3.csproj" ReferenceOutputAssembly="false" />
+        <ProjectReference Include="../Jab.Roslyn3/Jab.Roslyn3.csproj"
+                          OutputItemType="None"
+                          ReferenceOutputAssembly="false"
+                          Pack="true"
+                          PackagePath="analyzers/dotnet/roslyn3.11"
+                          Condition="'$(OmitRoslyn3AnalyzerFromPackage)' != 'true'" />
     </ItemGroup>
 
     <ItemGroup>
@@ -30,16 +35,6 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     </ItemGroup>
-    
-    <Target Name="ReferenceCrossTargeting" BeforeTargets="_GetPackageFiles">
-        <MSBuild Projects="../Jab.Roslyn3/Jab.Roslyn3.csproj" Targets="GetTargetPath">
-            <Output ItemName="Roslyn3Assembly" TaskParameter="TargetOutputs" />
-        </MSBuild>
-
-        <ItemGroup>
-            <None Include="%(Roslyn3Assembly.Identity)" Pack="true" PackagePath="analyzers/dotnet/roslyn3.11" Visible="false" />
-        </ItemGroup>
-    </Target>
     
     <Import Project="Jab.Common.props" />
 

--- a/src/Jab/Jab.csproj
+++ b/src/Jab/Jab.csproj
@@ -11,6 +11,7 @@
         <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
         <!-- Make sure that ResolveProjectReferences target runs before pack to include Jab for roslyn3. -->
         <BeforePack>$(BeforePack);ResolveProjectReferences</BeforePack>
+        <BuildProjectReferences Condition="'$(NoBuild)' == 'true'">false</BuildProjectReferences>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 


### PR DESCRIPTION
A separate MSBuild invocation into the Jab.Roslyn3 project isn't necessary. Instead the ProjectReference can emit its output data into the None item. Also adding a condition so that we in the source build can set this property to true to avoid roslyn3.11 prebuilts.