### PR TITLE
Fix Jab.Roslyn3.11 assembly name

### DIFF
--- a/src/Jab/Jab.Common.props
+++ b/src/Jab/Jab.Common.props
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <AssemblyName>Jab</AssemblyName>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <Version>0.8.0</Version>

--- a/src/Jab/build/Jab.targets
+++ b/src/Jab/build/Jab.targets
@@ -8,7 +8,7 @@
             BeforeTargets="CoreCompile">
         <ItemGroup>
             <Analyzer Remove="@(Analyzer)"
-                           Condition="$([System.String]::Copy('%(Analyzer.Identity)').IndexOf('Jab.dll')) &gt;= 0"/>
+                      Condition="$([System.String]::Copy('%(Analyzer.Identity)').IndexOf('roslyn4')) &gt;= 0"/>
         </ItemGroup>
     </Target>
 </Project>


### PR DESCRIPTION
The assembly name under analyzers/dotnet/roslyn3.11 is Jab.Roslyn3.dll which I believe is wrong and hence the assembly won't be picked up.

<img width="163" alt="image" src="https://user-images.githubusercontent.com/7412651/173128122-0be2e353-7672-4c5a-8d50-033021d76e35.png">
