### PR TITLE
Resolve RS1031 errors

### DIFF
--- a/src/Jab/DiagnosticDescriptors.cs
+++ b/src/Jab/DiagnosticDescriptors.cs
@@ -43,11 +43,11 @@ internal static class DiagnosticDescriptors
         "The service '{0}' is not registered", "Usage", DiagnosticSeverity.Error, true);
 
     public static readonly DiagnosticDescriptor ImplementationTypeAndFactoryNotAllowed = new("JAB0011",
-        "Can't specify both the implementation type and factory/instance.",
+        "Can't specify both the implementation type and factory/instance",
         "Can't specify both the implementation type and factory/instance, for service '{0}'", "Usage", DiagnosticSeverity.Error, true);
 
     public static readonly DiagnosticDescriptor FactoryMemberMustBeAMethodOrHaveDelegateType = new("JAB0012",
-        "The factory member has to be a method or have a delegate type.",
+        "The factory member has to be a method or have a delegate type",
         "The factory member '{0}' has to be a method of have a delegate type, for service '{1}'", "Usage", DiagnosticSeverity.Error, true);
 
 }


### PR DESCRIPTION
Encountered the following errors when building with the latest roslyn-analyzers version.

error RS1031: The diagnostic title should not contain a period, nor any line return character, nor any leading or trailing whitespaces