### PR TITLE
Enable generic attributes on .NET 7 and higher

### DIFF
--- a/src/Jab/build/Jab.targets
+++ b/src/Jab/build/Jab.targets
@@ -1,6 +1,8 @@
 <Project>
     <PropertyGroup>
-        <DefineConstants Condition="'$(TargetFramework)' == 'net6.0' AND '$(LangVersion)'=='preview'" >$(DefineConstants);JAB_PREVIEW</DefineConstants>
+        <DefineConstants Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND
+		                            ($([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '7.0')) OR
+									($([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0')) AND '$(LangVersion)'=='preview'))">$(DefineConstants);JAB_PREVIEW</DefineConstants>
     </PropertyGroup>
     <Target Name="_JabMultiTargetRoslyn3"
             Condition="'$(SupportsRoslynComponentVersioning)' != 'true'"


### PR DESCRIPTION
Instead of checking that the framework version is 6 and language version is preview check following:

- Target framework identifier is .NET Core
- Framework version is >= 7.0 or (Framework version >= 6.0 and Language version is preview)

Fixes #127