### PR TITLE
Add failing test for CreateScope

### DIFF
--- a/src/Jab.FunctionalTests.Common/ContainerTests.cs
+++ b/src/Jab.FunctionalTests.Common/ContainerTests.cs
@@ -741,6 +741,23 @@ namespace JabTests
         [Transient(typeof(IService), typeof(ServiceImplementation))]
         internal partial class CanResolveServicesUsingIServiceProviderContainer { }
 
+
+        [Fact]
+        public void CanResolveIServiceProviderNonGeneric()
+        {
+            CanResolveServicesUsingIServiceProviderContainer c = new();
+            IServiceProvider serviceProvider = c;
+
+            var scope = c.CreateScope();
+            IServiceProvider scopeServiceProvider = scope;
+
+            Assert.Same(c, serviceProvider.GetService(typeof(IServiceProvider)));
+            Assert.Same(scope, scopeServiceProvider.GetService(typeof(IServiceProvider)));
+        }
+
+        [ServiceProvider]
+        internal partial class CanResolveIServiceProviderNonGenericContainer { }
+
         [Fact]
         public void CanResolveIServiceProvider()
         {

--- a/src/Jab.FunctionalTests.MEDI/MEDIContainerTests.cs
+++ b/src/Jab.FunctionalTests.MEDI/MEDIContainerTests.cs
@@ -25,13 +25,18 @@ namespace JabTests
         [Fact]
         public void CanCreateScopeUsingExtensionMethod()
         {
-            CanResolveIServiceScopeFactoryContainer c = new();
+            CanCreateScopeContainer c = new();
             var scope = ((IServiceProvider)c).CreateScope();
-            Assert.IsType<CanResolveIServiceScopeFactoryContainer.Scope>(scope);
+            Assert.IsType<CanCreateScopeContainer.Scope>(scope);
         }
 
         [ServiceProvider]
         internal partial class CanResolveIServiceScopeFactoryContainer
+        {
+        }
+
+        [ServiceProvider]
+        internal partial class CanCreateScopeContainer
         {
         }
     }

--- a/src/Jab/ServiceProviderBuilder.cs
+++ b/src/Jab/ServiceProviderBuilder.cs
@@ -199,7 +199,14 @@ internal class ServiceProviderBuilder
                 new ServiceResolutionContext(description, callSites, registration.ServiceType, registration.Location));
         }
 
-        foreach (var rootService in description.RootServices)
+        List<RootService> rootServices = new(description.RootServices);
+        rootServices.Add(new(_knownTypes.IServiceProviderType, null));
+        if (_knownTypes.IServiceScopeFactoryType != null)
+        {
+            rootServices.Add(new(_knownTypes.IServiceScopeFactoryType, null));
+        }
+
+        foreach (var rootService in rootServices)
         {
             var serviceType = rootService.Service;
             var callSite = GetCallSite(serviceType,


### PR DESCRIPTION
If there is a call like: `c.GetService<IServiceScopeFactory>()` `IServiceScopeFactory` type is registered in `RootCallSites` and an entry is generated for it: https://github.com/pakrym/jab/blob/aab09936addd9a82dc483efb73290abf03bb0645/src/Jab/ContainerGenerator.cs#L333

Use a separate container and test fails with an exception:

```
Message: 
    System.InvalidOperationException : No service for type 'Microsoft.Extensions.DependencyInjection.IServiceScopeFactory' has been registered.

  Stack Trace: 
    ServiceProviderServiceExtensions.GetRequiredService(IServiceProvider provider, Type serviceType)
    ServiceProviderServiceExtensions.GetRequiredService[T](IServiceProvider provider)
    ServiceProviderServiceExtensions.CreateScope(IServiceProvider provider)
    MEDIContainerTests.CanCreateScopeUsingExtensionMethod() line 29
    RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
    MethodInvoker.Invoke(Object obj, IntPtr* args, BindingFlags invokeAttr)
```