### PR TITLE
Support .NET 8.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,12 +23,13 @@ jobs:
           3.1.x
           6.0.x
           7.0.x
+          8.0.x
     - name: Build
       run: dotnet build src
     - name: Test
       run: dotnet test src --no-build --verbosity normal
     - name: Pack
-      run: dotnet pack src --no-build --output nuget /p:ReleaseVersion=${{ github.event.inputs.ReleaseVersion }}
+      run: dotnet pack src --output nuget /p:ReleaseVersion=${{ github.event.inputs.ReleaseVersion }}
     - name: Get package version
       shell: pwsh
       id: vars

--- a/src/Jab.FunctionalTests.Common/Jab.FunctionalTest.props
+++ b/src/Jab.FunctionalTests.Common/Jab.FunctionalTest.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <DefaultFunctionalTestTargetFrameworks>netcoreapp3.1;net6.0;net7.0;netstandard2.0</DefaultFunctionalTestTargetFrameworks>
+    <DefaultFunctionalTestTargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0;netstandard2.0</DefaultFunctionalTestTargetFrameworks>
     <DefaultFunctionalTestTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))" >$(DefaultFunctionalTestTargetFrameworks);net472</DefaultFunctionalTestTargetFrameworks>
     <FunctionalTestTargetFrameworks Condition="'$(FunctionalTestTargetFrameworks)' == ''">$(DefaultFunctionalTestTargetFrameworks)</FunctionalTestTargetFrameworks>
     <IsPackable>false</IsPackable>

--- a/src/Jab.FunctionalTests.MEDI/Jab.FunctionalTests.MEDI.csproj
+++ b/src/Jab.FunctionalTests.MEDI/Jab.FunctionalTests.MEDI.csproj
@@ -7,9 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Condition="'$(TargetFramework)' == 'net472'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0"/>
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0"/>
     <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp3.1'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0"/>
     <PackageReference Condition="'$(TargetFramework)' == 'net6.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0"/>
     <PackageReference Condition="'$(TargetFramework)' == 'net7.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
+    <PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0"/>
   </ItemGroup>
 </Project>

--- a/src/Jab.Performance/Jab.Performance.csproj
+++ b/src/Jab.Performance/Jab.Performance.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Jab.Tests/Jab.Tests.csproj
+++ b/src/Jab.Tests/Jab.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## The issue or feature being addressed
Ensure that Jab is compatible with .NET 8.0 SDK.

## Details on the issue fix or feature implementation
Add target to .NET 8.0 for testing and benchmarking projects.