### PR TITLE
Non transient value type error

### DIFF
--- a/src/Jab.FunctionalTests.Common/ContainerTests.cs
+++ b/src/Jab.FunctionalTests.Common/ContainerTests.cs
@@ -1241,6 +1241,19 @@ namespace JabTests
         {
             Func<IService> Instance = () => new ServiceImplementation();
         }
+
+        [Fact]
+        public void SupportsScopedValueType()
+        {
+            SupportsScopedValueTypeContainer c = new();
+            Assert.IsType<int>(c.GetService<int>());
+        }
+
+        [ServiceProvider]
+        [Scoped(typeof(int))]
+        internal partial class SupportsScopedValueTypeContainer
+        {
+        }
     }
 }
 

--- a/src/Jab.FunctionalTests.Common/ContainerTests.cs
+++ b/src/Jab.FunctionalTests.Common/ContainerTests.cs
@@ -1272,10 +1272,10 @@ namespace JabTests
         [Singleton(typeof(IAnotherService), typeof(AnotherServiceImplementation), Name="OnlyNamed")]
         [Singleton(typeof(ServiceImplementationWithNamed<IService>))]
         internal partial class SupportsNamedServicesContainer
-		{
-		}
+        {
+        }
 
-		[Fact]
+        [Fact]
         public void SupportsNoneTransientValueType()
         {
             SupportsNoneTransientValueTypeContainer c = new();

--- a/src/Jab.FunctionalTests.Common/ContainerTests.cs
+++ b/src/Jab.FunctionalTests.Common/ContainerTests.cs
@@ -1276,15 +1276,17 @@ namespace JabTests
 		}
 
 		[Fact]
-        public void SupportsScopedValueType()
+        public void SupportsNoneTransientValueType()
         {
-            SupportsScopedValueTypeContainer c = new();
+            SupportsNoneTransientValueTypeContainer c = new();
             Assert.IsType<int>(c.GetService<int>());
+            Assert.IsType<float>(c.GetService<float>());
         }
 
         [ServiceProvider]
         [Scoped(typeof(int))]
-        internal partial class SupportsScopedValueTypeContainer
+        [Singleton(typeof(float))]
+        internal partial class SupportsNoneTransientValueTypeContainer
         {
         }
     }

--- a/src/Jab/ContainerGenerator.cs
+++ b/src/Jab/ContainerGenerator.cs
@@ -24,9 +24,9 @@ public partial class ContainerGenerator : DiagnosticAnalyzer
         if (serviceCallSite.Lifetime != ServiceLifetime.Transient)
         {
             var cacheLocation = GetCacheLocation(serviceCallSite.Identity);
-            codeWriter.Line($"if ({cacheLocation} == default)");
+            codeWriter.Line($"if ({cacheLocation} == null)");
             codeWriter.Line($"lock (this)");
-            using (codeWriter.Scope($"if ({cacheLocation} == default)"))
+            using (codeWriter.Scope($"if ({cacheLocation} == null)"))
             {
                 GenerateCallSite(
                     codeWriter,
@@ -40,7 +40,7 @@ public partial class ContainerGenerator : DiagnosticAnalyzer
 
             if (serviceCallSite.ImplementationType.IsValueType)
             {
-                valueCallback(codeWriter, w => w.Append($"{cacheLocation}!.Value"));
+                valueCallback(codeWriter, w => w.Append($"{cacheLocation}.Value"));
             }
             else
             {

--- a/src/Jab/ContainerGenerator.cs
+++ b/src/Jab/ContainerGenerator.cs
@@ -35,7 +35,14 @@ public partial class ContainerGenerator : DiagnosticAnalyzer
                     });
             }
 
-            valueCallback(codeWriter, w => w.Append($"{cacheLocation}"));
+            if (serviceCallSite.ServiceType.IsValueType)
+            {
+                valueCallback(codeWriter, w => w.Append($"{cacheLocation}!.Value"));
+            }
+            else
+            {
+                valueCallback(codeWriter, w => w.Append($"{cacheLocation}"));
+            }
         }
         else if (serviceCallSite.IsDisposable != false)
         {

--- a/src/Jab/ContainerGenerator.cs
+++ b/src/Jab/ContainerGenerator.cs
@@ -38,7 +38,7 @@ public partial class ContainerGenerator : DiagnosticAnalyzer
                     });
             }
 
-            if (serviceCallSite.ServiceType.IsValueType)
+            if (serviceCallSite.ImplementationType.IsValueType)
             {
                 valueCallback(codeWriter, w => w.Append($"{cacheLocation}!.Value"));
             }


### PR DESCRIPTION
If you register a value type as singleton or scoped you get a compile error.

The compile error happens because there's a nullable field saved for each registration, which in reference type is implicitly castable to the implementation type, but in value type you have to cast it manually or use the Value property.

The 1st commit is a Unit Test showcasing the problem