### PR TITLE
Remove end of life .NET versions and add .NET 9.0 support

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Publish unity packages to npm
       shell: pwsh
       run: |

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,9 +20,6 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-          3.1.x
-          6.0.x
-          7.0.x
           8.0.x
           9.0.x
     - name: Build
@@ -56,15 +53,9 @@ jobs:
     strategy:
       matrix:
         sdk: 
-          - 6.0.x
-          - 7.0.x
           - 8.0.x
           - 9.0.x
         include:
-          - sdk: 6.0.x
-            tfm: net6.0
-          - sdk: 7.0.x
-            tfm: net7.0
           - sdk: 8.0.x
             tfm: net8.0
           - sdk: 9.0.x
@@ -104,7 +95,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Publish unity packages to npm
       shell: pwsh
       run: |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Jab provides a [C# Source Generator](https://devblogs.microsoft.com/dotnet/intro
 - Clean stack traces: <br> ![stacktrace](https://raw.githubusercontent.com/pakrym/jab/main/doc/stacktrace.png)
 - Readable generated code: <br> ![generated code](https://raw.githubusercontent.com/pakrym/jab/main/doc/generatedcode.png)
 - Registration validation. Container configuration issues become compiler errors: <br> ![generated code](https://raw.githubusercontent.com/pakrym/jab/main/doc/errors.png)
-- Incremental generation, .NET 5/6/7/8 SDK support, .NET Standard 2.0 support, [Unity support](README.md#Unity-installation)
+- Incremental generation, Modern .NET SDK support, .NET Standard 2.0 support, [Unity support](README.md#Unity-installation)
 
 ## Example
 
@@ -169,18 +169,10 @@ When the scope is disposed all `IDisposable` and `IAsyncDisposable` services tha
 
 ### Generic registration attributes 
 
-You can use generic attributes to register services if your project targets `net7.0` or `net6.0` and has `LangVersion` set to preview.
 
-```xml
-<Project Sdk="Microsoft.NET.Sdk">
+You can use generic attributes to register services if your project targets a framework compatible with C# 11 or greater. See [C# language versioning](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-versioning#defaults) for more details.
 
-  <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
-  </PropertyGroup>
 
-</Project>
-
-```
 
 Generic attributes allow declaration to be more compact by avoiding the `typeof` calls:
 

--- a/src/Jab.FunctionalTests.Common/Jab.FunctionalTest.props
+++ b/src/Jab.FunctionalTests.Common/Jab.FunctionalTest.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <DefaultFunctionalTestTargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0;net9.0;netstandard2.0</DefaultFunctionalTestTargetFrameworks>
+    <DefaultFunctionalTestTargetFrameworks>net8.0;net9.0;netstandard2.0</DefaultFunctionalTestTargetFrameworks>
     <DefaultFunctionalTestTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))" >$(DefaultFunctionalTestTargetFrameworks);net472</DefaultFunctionalTestTargetFrameworks>
     <FunctionalTestTargetFrameworks Condition="'$(FunctionalTestTargetFrameworks)' == ''">$(DefaultFunctionalTestTargetFrameworks)</FunctionalTestTargetFrameworks>
     <IsPackable>false</IsPackable>

--- a/src/Jab.FunctionalTests.Common/Jab.FunctionalTests.Common.props
+++ b/src/Jab.FunctionalTests.Common/Jab.FunctionalTests.Common.props
@@ -4,18 +4,18 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" Condition="'$(TargetFramework)' != 'netstandard2.0'">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" Condition="'$(TargetFramework)' != 'netstandard2.0'">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
 	<!-- Override transitive package version System.Formats.Asn1 to address vulnerability: https://github.com/advisories/GHSA-447r-wph3-92pm -->
-	<PackageReference Include="System.Formats.Asn1" Version="9.0.0" />
+	<PackageReference Include="System.Formats.Asn1" Version="9.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
 	  <ProjectReference Include="..\Jab.FunctionalTests.Module\Jab.FunctionalTests.Module.csproj" />
     <Compile Include="$(MSBuildThisFileDirectory)\**\*.cs" />

--- a/src/Jab.FunctionalTests.Common/Jab.FunctionalTests.Common.props
+++ b/src/Jab.FunctionalTests.Common/Jab.FunctionalTests.Common.props
@@ -3,20 +3,21 @@
   <Import Project="$(MSBuildThisFileDirectory)/Jab.FunctionalTest.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" Condition="'$(TargetFramework)' != 'netstandard2.0'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" Condition="'$(TargetFramework)' != 'netstandard2.0'">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
+	<!-- Override transitive package version System.Formats.Asn1 to address vulnerability: https://github.com/advisories/GHSA-447r-wph3-92pm -->
+	<PackageReference Include="System.Formats.Asn1" Version="9.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
-
-    <ProjectReference Include="..\Jab.FunctionalTests.Module\Jab.FunctionalTests.Module.csproj" />
+	  <ProjectReference Include="..\Jab.FunctionalTests.Module\Jab.FunctionalTests.Module.csproj" />
     <Compile Include="$(MSBuildThisFileDirectory)\**\*.cs" />
   </ItemGroup>
 

--- a/src/Jab.FunctionalTests.MEDI/Jab.FunctionalTests.MEDI.csproj
+++ b/src/Jab.FunctionalTests.MEDI/Jab.FunctionalTests.MEDI.csproj
@@ -9,9 +9,6 @@
   <ItemGroup>
     <PackageReference Condition="'$(TargetFramework)' == 'net472'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0"/>
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0"/>
-    <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp3.1'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0"/>
-    <PackageReference Condition="'$(TargetFramework)' == 'net6.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0"/>
-    <PackageReference Condition="'$(TargetFramework)' == 'net7.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
     <PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0"/>
     <PackageReference Condition="'$(TargetFramework)' == 'net9.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0"/>
   </ItemGroup>

--- a/src/Jab.FunctionalTests.MEDI/Jab.FunctionalTests.MEDI.csproj
+++ b/src/Jab.FunctionalTests.MEDI/Jab.FunctionalTests.MEDI.csproj
@@ -10,6 +10,6 @@
     <PackageReference Condition="'$(TargetFramework)' == 'net472'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0"/>
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0"/>
     <PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"/>
-    <PackageReference Condition="'$(TargetFramework)' == 'net9.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0"/>
+    <PackageReference Condition="'$(TargetFramework)' == 'net9.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1"/>
   </ItemGroup>
 </Project>

--- a/src/Jab.FunctionalTests.MEDI/Jab.FunctionalTests.MEDI.csproj
+++ b/src/Jab.FunctionalTests.MEDI/Jab.FunctionalTests.MEDI.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Condition="'$(TargetFramework)' == 'net472'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0"/>
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0"/>
-    <PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0"/>
+    <PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"/>
     <PackageReference Condition="'$(TargetFramework)' == 'net9.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0"/>
   </ItemGroup>
 </Project>

--- a/src/Jab.Performance/Jab.Performance.csproj
+++ b/src/Jab.Performance/Jab.Performance.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Jab.Performance/Jab.Performance.csproj
+++ b/src/Jab.Performance/Jab.Performance.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Jab" Version="0.10.2" PrivateAssets="all" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Jab.Performance/Jab.Performance.csproj
+++ b/src/Jab.Performance/Jab.Performance.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Jab" Version="0.10.2" PrivateAssets="all" />
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Jab.Tests/Jab.Tests.csproj
+++ b/src/Jab.Tests/Jab.Tests.csproj
@@ -10,18 +10,18 @@
     <Content Include="..\Jab\Attributes.cs" CopyToOutputDirectory="PreserveNewest" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
 	<!-- Override transitive package version System.Formats.Asn1 to address vulnerability: https://github.com/advisories/GHSA-447r-wph3-92pm -->
-	<PackageReference Include="System.Formats.Asn1" Version="9.0.0" />
+	<PackageReference Include="System.Formats.Asn1" Version="9.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
   </ItemGroup>
 </Project>

--- a/src/Jab.Tests/Jab.Tests.csproj
+++ b/src/Jab.Tests/Jab.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Jab.Tests/Jab.Tests.csproj
+++ b/src/Jab.Tests/Jab.Tests.csproj
@@ -9,17 +9,19 @@
 
     <Content Include="..\Jab\Attributes.cs" CopyToOutputDirectory="PreserveNewest" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
+	<!-- Override transitive package version System.Formats.Asn1 to address vulnerability: https://github.com/advisories/GHSA-447r-wph3-92pm -->
+	<PackageReference Include="System.Formats.Asn1" Version="9.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
   </ItemGroup>
 </Project>

--- a/src/Jab/Jab.csproj
+++ b/src/Jab/Jab.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
@@ -38,7 +38,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
     
     <Import Project="Jab.Common.props" />

--- a/src/samples/ConsoleSample/ConsoleSample.csproj
+++ b/src/samples/ConsoleSample/ConsoleSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/samples/ConsoleSample/ConsoleSample.csproj
+++ b/src/samples/ConsoleSample/ConsoleSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
- Removes [end-of-life](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle) .NET versions

- Adds support for .NET 9

- Updates dependency packages to addresses transitive vulnerabilities
This resolves build failures caused by [Nuget vulnerability warnings](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1901-nu1904) getting treated as errors in some projects. `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`

A few other packages do have updates available but are not causing any build issues so have left those for now.


All tests are passing successfully.