### PR TITLE
Allow auto-dispose of factory generated services

### DIFF
--- a/src/Jab.FunctionalTests.Common/ContainerTests.cs
+++ b/src/Jab.FunctionalTests.Common/ContainerTests.cs
@@ -548,9 +548,9 @@ namespace JabTests
         internal partial class DisposingScopeDisposesServicesContainer { }
 
         [Fact]
-        public void DisposingScopeDisposesFactoryGeneratedServicesWhenInstructedTo()
+        public void DisposingScopeDisposesFactoryGeneratedServices()
         {
-            DisposingScopeDisposesFactoryGeneratedServicesWhenInstructedToServicesContainer c = new();
+            DisposingScopeDisposesFactoryGeneratedServicesContainer c = new();
             var scope = c.CreateScope();
             var service = Assert.IsType<DisposableServiceImplementation>(scope.GetService<IService>());
 
@@ -560,27 +560,8 @@ namespace JabTests
         }
 
         [ServiceProvider]
-        [Scoped(typeof(IService), Factory = nameof(CreateDisposableService), AutoDispose = true)]
-        internal partial class DisposingScopeDisposesFactoryGeneratedServicesWhenInstructedToServicesContainer
-        {
-            private static IService CreateDisposableService() => new DisposableServiceImplementation();
-        }
-
-        [Fact]
-        public void DisposingScopeDoesNotDisposeFactoryGeneratedServicesWhenNotInstructedTo()
-        {
-            DisposingScopeDoesNotDisposeFactoryGeneratedServicesWhenNotInstructedToServicesContainer c = new();
-            var scope = c.CreateScope();
-            var service = Assert.IsType<DisposableServiceImplementation>(scope.GetService<IService>());
-
-            scope.Dispose();
-
-            Assert.Equal(0, service.DisposalCount);
-        }
-
-        [ServiceProvider]
         [Scoped(typeof(IService), Factory = nameof(CreateDisposableService))]
-        internal partial class DisposingScopeDoesNotDisposeFactoryGeneratedServicesWhenNotInstructedToServicesContainer
+        internal partial class DisposingScopeDisposesFactoryGeneratedServicesContainer
         {
             private static IService CreateDisposableService() => new DisposableServiceImplementation();
         }
@@ -612,9 +593,9 @@ namespace JabTests
         internal partial class DisposingScopeDisposesAsyncServicesContainer { }
 
         [Fact]
-        public async Task DisposingScopeDisposesFactoryGeneratedAsyncServicesWhenInstructedTo()
+        public async Task DisposingScopeDisposesFactoryGeneratedAsyncServices()
         {
-            DisposingScopeDisposesFactoryGeneratedAsyncServicesWhenInstructedToServicesContainer c = new();
+            DisposingScopeDisposesFactoryGeneratedAsyncServicesContainer c = new();
             var scope = c.CreateScope();
             var service = Assert.IsType<AsyncDisposableServiceImplementation>(scope.GetService<IService>());
 
@@ -633,36 +614,8 @@ namespace JabTests
         }
 
         [ServiceProvider]
-        [Scoped(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
-        internal partial class DisposingScopeDisposesFactoryGeneratedAsyncServicesWhenInstructedToServicesContainer
-        {
-            private static IService CreateService() => new AsyncDisposableServiceImplementation();
-        }
-
-        [Fact]
-        public async Task DisposingScopeDoesNotDisposeFactoryGeneratedAsyncServicesWhenNotInstructedTo()
-        {
-            DisposingScopeDoesNotDisposeFactoryGeneratedAsyncServicesWhenNotInstructedToServicesContainer c = new();
-            var scope = c.CreateScope();
-            var service = Assert.IsType<AsyncDisposableServiceImplementation>(scope.GetService<IService>());
-
-            await scope.DisposeAsync();
-
-            Assert.Equal(0, service.AsyncDisposalCount);
-            Assert.Equal(0, service.DisposalCount);
-
-            scope = c.CreateScope();
-            service = Assert.IsType<AsyncDisposableServiceImplementation>(scope.GetService<IService>());
-
-            scope.Dispose();
-
-            Assert.Equal(0, service.AsyncDisposalCount);
-            Assert.Equal(0, service.DisposalCount);
-        }
-
-        [ServiceProvider]
         [Scoped(typeof(IService), Factory = nameof(CreateService))]
-        internal partial class DisposingScopeDoesNotDisposeFactoryGeneratedAsyncServicesWhenNotInstructedToServicesContainer
+        internal partial class DisposingScopeDisposesFactoryGeneratedAsyncServicesContainer
         {
             private static IService CreateService() => new AsyncDisposableServiceImplementation();
         }
@@ -686,7 +639,7 @@ namespace JabTests
         [Fact]
         public void DisposingProviderDisposesFactoryGeneratedRootScopedServicesIfInstructedTo()
         {
-            DisposingProviderDisposesFactoryGeneratedRootScopedServicesIfInstructedToServicesContainer c = new();
+            DisposingProviderDisposesFactoryGeneratedRootScopedServicesContainer c = new();
             var service = Assert.IsType<DisposableServiceImplementation>(c.GetService<IService>());
 
             c.Dispose();
@@ -695,26 +648,8 @@ namespace JabTests
         }
 
         [ServiceProvider]
-        [Scoped(typeof(IService), Factory = nameof(GenerateService), AutoDispose = true)]
-        internal partial class DisposingProviderDisposesFactoryGeneratedRootScopedServicesIfInstructedToServicesContainer
-        {
-            private static IService GenerateService() => new DisposableServiceImplementation();
-        }
-
-        [Fact]
-        public void DisposingProviderDoesNotDisposeFactoryGeneratedRootScopedServicesIfNotInstructedTo()
-        {
-            DisposingProviderDoesNotDisposeFactoryGeneratedRootScopedServicesIfNotInstructedToServicesContainer c = new();
-            var service = Assert.IsType<DisposableServiceImplementation>(c.GetService<IService>());
-
-            c.Dispose();
-
-            Assert.Equal(0, service.DisposalCount);
-        }
-
-        [ServiceProvider]
         [Scoped(typeof(IService), Factory = nameof(GenerateService))]
-        internal partial class DisposingProviderDoesNotDisposeFactoryGeneratedRootScopedServicesIfNotInstructedToServicesContainer
+        internal partial class DisposingProviderDisposesFactoryGeneratedRootScopedServicesContainer
         {
             private static IService GenerateService() => new DisposableServiceImplementation();
         }
@@ -735,9 +670,9 @@ namespace JabTests
         internal partial class DisposingProviderDisposesRootSingletonServicesContainer { }
 
         [Fact]
-        public void DisposingProviderDisposesFactoryGeneratedRootSingletonServicesWhenInstructedTo()
+        public void DisposingProviderDisposesFactoryGeneratedRootSingletonServices()
         {
-            DisposingProviderDisposesFactoryGeneratedRootSingletonServicesWhenInstructedToServicesContainer c = new();
+            DisposingProviderDisposesFactoryGeneratedRootSingletonServicesContainer c = new();
             var service = Assert.IsType<DisposableServiceImplementation>(c.GetService<IService>());
 
             c.Dispose();
@@ -746,26 +681,8 @@ namespace JabTests
         }
 
         [ServiceProvider]
-        [Singleton(typeof(IService), Factory = nameof(GetService), AutoDispose = true)]
-        internal partial class DisposingProviderDisposesFactoryGeneratedRootSingletonServicesWhenInstructedToServicesContainer
-        {
-            private static IService GetService() => new DisposableServiceImplementation();
-        }
-
-        [Fact]
-        public void DisposingProviderDoesNotDisposeFactoryGeneratedRootSingletonServicesWhenNotInstructedTo()
-        {
-            DisposingProviderDoesNotDisposeFactoryGeneratedRootSingletonServicesWhenNotInstructedToServicesContainer c = new();
-            var service = Assert.IsType<DisposableServiceImplementation>(c.GetService<IService>());
-
-            c.Dispose();
-
-            Assert.Equal(0, service.DisposalCount);
-        }
-
-        [ServiceProvider]
         [Singleton(typeof(IService), Factory = nameof(GetService))]
-        internal partial class DisposingProviderDoesNotDisposeFactoryGeneratedRootSingletonServicesWhenNotInstructedToServicesContainer
+        internal partial class DisposingProviderDisposesFactoryGeneratedRootSingletonServicesContainer
         {
             private static IService GetService() => new DisposableServiceImplementation();
         }
@@ -788,9 +705,9 @@ namespace JabTests
         internal partial class DisposingProviderDisposesRootSingAsyncServicesContainer { }
 
         [Fact]
-        public async Task DisposingProviderDisposesFactoryGeneratedRootSingAsyncServicesWhenInstructedTo()
+        public async Task DisposingProviderDisposesFactoryGeneratedRootSingAsyncServices()
         {
-            DisposingProviderDisposesFactoryGeneratedRootSingAsyncServicesWhenInstructedToServicesContainer c = new();
+            DisposingProviderDisposesFactoryGeneratedRootSingAsyncServicesContainer c = new();
             var service = Assert.IsType<AsyncDisposableServiceImplementation>(c.GetService<IService>());
 
             await c.DisposeAsync();
@@ -800,27 +717,8 @@ namespace JabTests
         }
 
         [ServiceProvider]
-        [Scoped(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
-        internal partial class DisposingProviderDisposesFactoryGeneratedRootSingAsyncServicesWhenInstructedToServicesContainer
-        {
-            private static IService CreateService() => new AsyncDisposableServiceImplementation();
-        }
-
-        [Fact]
-        public async Task DisposingProviderDoesNotDisposeFactoryGeneratedRootSingAsyncServicesWhenNotInstructedTo()
-        {
-            DisposingProviderDoesNotDisposeFactoryGeneratedRootSingAsyncServicesWhenNotInstructedToServicesContainer c = new();
-            var service = Assert.IsType<AsyncDisposableServiceImplementation>(c.GetService<IService>());
-
-            await c.DisposeAsync();
-
-            Assert.Equal(0, service.AsyncDisposalCount);
-            Assert.Equal(0, service.DisposalCount);
-        }
-
-        [ServiceProvider]
         [Scoped(typeof(IService), Factory = nameof(CreateService))]
-        internal partial class DisposingProviderDoesNotDisposeFactoryGeneratedRootSingAsyncServicesWhenNotInstructedToServicesContainer
+        internal partial class DisposingProviderDisposesFactoryGeneratedRootSingAsyncServicesContainer
         {
             private static IService CreateService() => new AsyncDisposableServiceImplementation();
         }
@@ -851,7 +749,7 @@ namespace JabTests
         [Fact]
         public async Task DisposingProviderDisposesAllFactoryGeneratedSingletonEnumerableServicesWhenInstructedTo()
         {
-            DisposingProviderDisposesAllFactoryGeneratedSingletonEnumerableServicesWhenInstructedToServicesContainer c = new();
+            DisposingProviderDisposesAllFactoryGeneratedSingletonEnumerableServicesContainer c = new();
             var services = Assert.IsType<IService[]>(c.GetService<IEnumerable<IService>>());
 
             await c.DisposeAsync();
@@ -864,35 +762,10 @@ namespace JabTests
         }
 
         [ServiceProvider]
-        [Scoped(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
-        [Scoped(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
-        [Scoped(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
-        internal partial class DisposingProviderDisposesAllFactoryGeneratedSingletonEnumerableServicesWhenInstructedToServicesContainer
-        {
-            private static IService CreateService() => new DisposableServiceImplementation();
-        }
-
-        [Fact]
-        public async Task DisposingProviderDisposesOnlyFactoryGeneratedSingletonEnumerableServicesThatAreRegisteredToDispose()
-        {
-            DisposingProviderDisposesOnlyFactoryGeneratedSingletonEnumerableServicesThatAreRegisteredToDisposeServicesContainer c = new();
-            var services = Assert.IsType<IService[]>(c.GetService<IEnumerable<IService>>());
-
-            await c.DisposeAsync();
-
-            for (int i = 0; i < services.Length; i++)
-            {
-                var disposableService = Assert.IsType<DisposableServiceImplementation>(services[i]);
-                Assert.Equal(i % 2, disposableService.DisposalCount);
-            }
-        }
-
-        [ServiceProvider]
         [Scoped(typeof(IService), Factory = nameof(CreateService))]
-        [Scoped(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
         [Scoped(typeof(IService), Factory = nameof(CreateService))]
-        [Scoped(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
-        internal partial class DisposingProviderDisposesOnlyFactoryGeneratedSingletonEnumerableServicesThatAreRegisteredToDisposeServicesContainer
+        [Scoped(typeof(IService), Factory = nameof(CreateService))]
+        internal partial class DisposingProviderDisposesAllFactoryGeneratedSingletonEnumerableServicesContainer
         {
             private static IService CreateService() => new DisposableServiceImplementation();
         }
@@ -922,9 +795,9 @@ namespace JabTests
         internal partial class DisposingProviderDisposesTransientsContainer { }
 
         [Fact]
-        public void DisposingProviderDisposesFactoryGeneratedTransientsIfInstructedTo()
+        public void DisposingProviderDisposesFactoryGeneratedTransients()
         {
-            DisposingProviderDisposesFactoryGeneratedTransientsIfInstructedToContainer c = new();
+            DisposingProviderDisposesFactoryGeneratedTransientsContainer c = new();
             List<IService> services = new();
             for (int i = 0; i < 5; i++)
             {
@@ -941,34 +814,8 @@ namespace JabTests
         }
 
         [ServiceProvider]
-        [Transient(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
-        internal partial class DisposingProviderDisposesFactoryGeneratedTransientsIfInstructedToContainer
-        {
-            private static IService CreateService() => new DisposableServiceImplementation();
-        }
-
-        [Fact]
-        public void DisposingProviderDoesNotDisposeFactoryGeneratedTransientsIfNotInstructedTo()
-        {
-            DisposingProviderDoesNotDisposeFactoryGeneratedTransientsIfNotInstructedToContainer c = new();
-            List<IService> services = new();
-            for (int i = 0; i < 5; i++)
-            {
-                services.Add(c.GetService<IService>());
-            }
-
-            c.Dispose();
-
-            foreach (var service in services)
-            {
-                var disposableService = Assert.IsType<DisposableServiceImplementation>(service);
-                Assert.Equal(0, disposableService.DisposalCount);
-            }
-        }
-
-        [ServiceProvider]
         [Transient(typeof(IService), Factory = nameof(CreateService))]
-        internal partial class DisposingProviderDoesNotDisposeFactoryGeneratedTransientsIfNotInstructedToContainer
+        internal partial class DisposingProviderDisposesFactoryGeneratedTransientsContainer
         {
             private static IService CreateService() => new DisposableServiceImplementation();
         }
@@ -999,9 +846,9 @@ namespace JabTests
         internal partial class DisposingScopeDisposesTransientsContainer { }
 
         [Fact]
-        public void DisposingScopeDisposesFactoryGeneratedTransientsIfInstructedTo()
+        public void DisposingScopeDisposesFactoryGeneratedTransients()
         {
-            DisposingScopeDisposesFactoryGeneratedTransientsIfInstructedToContainer c = new();
+            DisposingScopeDisposesFactoryGeneratedTransientsContainer c = new();
             var scope = c.CreateScope();
 
             List<IService> services = new();
@@ -1020,44 +867,16 @@ namespace JabTests
         }
 
         [ServiceProvider]
-        [Transient(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
-        internal partial class DisposingScopeDisposesFactoryGeneratedTransientsIfInstructedToContainer
-        {
-            private IService CreateService() => new DisposableServiceImplementation();
-        }
-
-        [Fact]
-        public void DisposingScopeDoesNotDisposeFactoryGeneratedTransientsIfNotInstructedTo()
-        {
-            DisposingScopeDoesNotDisposeFactoryGeneratedTransientsIfNotInstructedToContainer c = new();
-            var scope = c.CreateScope();
-
-            List<IService> services = new();
-            for (int i = 0; i < 5; i++)
-            {
-                services.Add(scope.GetService<IService>());
-            }
-
-            scope.Dispose();
-
-            foreach (var service in services)
-            {
-                var disposableService = Assert.IsType<DisposableServiceImplementation>(service);
-                Assert.Equal(0, disposableService.DisposalCount);
-            }
-        }
-
-        [ServiceProvider]
         [Transient(typeof(IService), Factory = nameof(CreateService))]
-        internal partial class DisposingScopeDoesNotDisposeFactoryGeneratedTransientsIfNotInstructedToContainer
+        internal partial class DisposingScopeDisposesFactoryGeneratedTransientsContainer
         {
             private IService CreateService() => new DisposableServiceImplementation();
         }
 
         [Fact]
-        public void DisposingProviderDoesNotDisposeRootSingletonInstanceServicesEvenWithAutoDisposeFlagSet()
+        public void DisposingProviderDoesNotDisposeRootSingletonInstanceServices()
         {
-            DisposingProviderDoesNotDisposeRootSingletonInstanceServicesEvenWithAutoDisposeFlagSetContainer c = new();
+            DisposingProviderDoesNotDisposeRootSingletonInstanceServicesContainer c = new();
             var service = Assert.IsType<DisposableServiceImplementation>(c.GetService<IService>());
 
             c.Dispose();
@@ -1067,8 +886,8 @@ namespace JabTests
         }
 
         [ServiceProvider]
-        [Singleton(typeof(IService), Instance = nameof(DisposableServiceImplementation), AutoDispose = true)]
-        internal partial class DisposingProviderDoesNotDisposeRootSingletonInstanceServicesEvenWithAutoDisposeFlagSetContainer
+        [Singleton(typeof(IService), Instance = nameof(DisposableServiceImplementation))]
+        internal partial class DisposingProviderDoesNotDisposeRootSingletonInstanceServicesContainer
         {
             internal DisposableServiceImplementation DisposableServiceImplementation { get; } = new DisposableServiceImplementation();
         }

--- a/src/Jab.FunctionalTests.Common/ContainerTests.cs
+++ b/src/Jab.FunctionalTests.Common/ContainerTests.cs
@@ -547,6 +547,44 @@ namespace JabTests
         [Scoped(typeof(IService), typeof(DisposableServiceImplementation))]
         internal partial class DisposingScopeDisposesServicesContainer { }
 
+        [Fact]
+        public void DisposingScopeDisposesFactoryGeneratedServicesWhenInstructedTo()
+        {
+            DisposingScopeDisposesFactoryGeneratedServicesWhenInstructedToServicesContainer c = new();
+            var scope = c.CreateScope();
+            var service = Assert.IsType<DisposableServiceImplementation>(scope.GetService<IService>());
+
+            scope.Dispose();
+
+            Assert.Equal(1, service.DisposalCount);
+        }
+
+        [ServiceProvider]
+        [Scoped(typeof(IService), Factory = nameof(CreateDisposableService), AutoDispose = true)]
+        internal partial class DisposingScopeDisposesFactoryGeneratedServicesWhenInstructedToServicesContainer
+        {
+            private static IService CreateDisposableService() => new DisposableServiceImplementation();
+        }
+
+        [Fact]
+        public void DisposingScopeDoesNotDisposeFactoryGeneratedServicesWhenNotInstructedTo()
+        {
+            DisposingScopeDoesNotDisposeFactoryGeneratedServicesWhenNotInstructedToServicesContainer c = new();
+            var scope = c.CreateScope();
+            var service = Assert.IsType<DisposableServiceImplementation>(scope.GetService<IService>());
+
+            scope.Dispose();
+
+            Assert.Equal(0, service.DisposalCount);
+        }
+
+        [ServiceProvider]
+        [Scoped(typeof(IService), Factory = nameof(CreateDisposableService))]
+        internal partial class DisposingScopeDoesNotDisposeFactoryGeneratedServicesWhenNotInstructedToServicesContainer
+        {
+            private static IService CreateDisposableService() => new DisposableServiceImplementation();
+        }
+
 #if NETCOREAPP
         [Fact]
         public async Task DisposingScopeDisposesAsyncServices()
@@ -572,6 +610,62 @@ namespace JabTests
         [ServiceProvider]
         [Scoped(typeof(IService), typeof(AsyncDisposableServiceImplementation))]
         internal partial class DisposingScopeDisposesAsyncServicesContainer { }
+
+        [Fact]
+        public async Task DisposingScopeDisposesFactoryGeneratedAsyncServicesWhenInstructedTo()
+        {
+            DisposingScopeDisposesFactoryGeneratedAsyncServicesWhenInstructedToServicesContainer c = new();
+            var scope = c.CreateScope();
+            var service = Assert.IsType<AsyncDisposableServiceImplementation>(scope.GetService<IService>());
+
+            await scope.DisposeAsync();
+
+            Assert.Equal(1, service.AsyncDisposalCount);
+            Assert.Equal(0, service.DisposalCount);
+
+            scope = c.CreateScope();
+            service = Assert.IsType<AsyncDisposableServiceImplementation>(scope.GetService<IService>());
+
+            scope.Dispose();
+
+            Assert.Equal(0, service.AsyncDisposalCount);
+            Assert.Equal(1, service.DisposalCount);
+        }
+
+        [ServiceProvider]
+        [Scoped(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
+        internal partial class DisposingScopeDisposesFactoryGeneratedAsyncServicesWhenInstructedToServicesContainer
+        {
+            private static IService CreateService() => new AsyncDisposableServiceImplementation();
+        }
+
+        [Fact]
+        public async Task DisposingScopeDoesNotDisposeFactoryGeneratedAsyncServicesWhenNotInstructedTo()
+        {
+            DisposingScopeDoesNotDisposeFactoryGeneratedAsyncServicesWhenNotInstructedToServicesContainer c = new();
+            var scope = c.CreateScope();
+            var service = Assert.IsType<AsyncDisposableServiceImplementation>(scope.GetService<IService>());
+
+            await scope.DisposeAsync();
+
+            Assert.Equal(0, service.AsyncDisposalCount);
+            Assert.Equal(0, service.DisposalCount);
+
+            scope = c.CreateScope();
+            service = Assert.IsType<AsyncDisposableServiceImplementation>(scope.GetService<IService>());
+
+            scope.Dispose();
+
+            Assert.Equal(0, service.AsyncDisposalCount);
+            Assert.Equal(0, service.DisposalCount);
+        }
+
+        [ServiceProvider]
+        [Scoped(typeof(IService), Factory = nameof(CreateService))]
+        internal partial class DisposingScopeDoesNotDisposeFactoryGeneratedAsyncServicesWhenNotInstructedToServicesContainer
+        {
+            private static IService CreateService() => new AsyncDisposableServiceImplementation();
+        }
 #endif
 
         [Fact]
@@ -590,6 +684,42 @@ namespace JabTests
         internal partial class DisposingProviderDisposesRootScopedServicesContainer { }
 
         [Fact]
+        public void DisposingProviderDisposesFactoryGeneratedRootScopedServicesIfInstructedTo()
+        {
+            DisposingProviderDisposesFactoryGeneratedRootScopedServicesIfInstructedToServicesContainer c = new();
+            var service = Assert.IsType<DisposableServiceImplementation>(c.GetService<IService>());
+
+            c.Dispose();
+
+            Assert.Equal(1, service.DisposalCount);
+        }
+
+        [ServiceProvider]
+        [Scoped(typeof(IService), Factory = nameof(GenerateService), AutoDispose = true)]
+        internal partial class DisposingProviderDisposesFactoryGeneratedRootScopedServicesIfInstructedToServicesContainer
+        {
+            private static IService GenerateService() => new DisposableServiceImplementation();
+        }
+
+        [Fact]
+        public void DisposingProviderDoesNotDisposeFactoryGeneratedRootScopedServicesIfNotInstructedTo()
+        {
+            DisposingProviderDoesNotDisposeFactoryGeneratedRootScopedServicesIfNotInstructedToServicesContainer c = new();
+            var service = Assert.IsType<DisposableServiceImplementation>(c.GetService<IService>());
+
+            c.Dispose();
+
+            Assert.Equal(0, service.DisposalCount);
+        }
+
+        [ServiceProvider]
+        [Scoped(typeof(IService), Factory = nameof(GenerateService))]
+        internal partial class DisposingProviderDoesNotDisposeFactoryGeneratedRootScopedServicesIfNotInstructedToServicesContainer
+        {
+            private static IService GenerateService() => new DisposableServiceImplementation();
+        }
+
+        [Fact]
         public void DisposingProviderDisposesRootSingletonServices()
         {
             DisposingProviderDisposesRootSingletonServicesContainer c = new();
@@ -603,6 +733,42 @@ namespace JabTests
         [ServiceProvider]
         [Singleton(typeof(IService), typeof(DisposableServiceImplementation))]
         internal partial class DisposingProviderDisposesRootSingletonServicesContainer { }
+
+        [Fact]
+        public void DisposingProviderDisposesFactoryGeneratedRootSingletonServicesWhenInstructedTo()
+        {
+            DisposingProviderDisposesFactoryGeneratedRootSingletonServicesWhenInstructedToServicesContainer c = new();
+            var service = Assert.IsType<DisposableServiceImplementation>(c.GetService<IService>());
+
+            c.Dispose();
+
+            Assert.Equal(1, service.DisposalCount);
+        }
+
+        [ServiceProvider]
+        [Singleton(typeof(IService), Factory = nameof(GetService), AutoDispose = true)]
+        internal partial class DisposingProviderDisposesFactoryGeneratedRootSingletonServicesWhenInstructedToServicesContainer
+        {
+            private static IService GetService() => new DisposableServiceImplementation();
+        }
+
+        [Fact]
+        public void DisposingProviderDoesNotDisposeFactoryGeneratedRootSingletonServicesWhenNotInstructedTo()
+        {
+            DisposingProviderDoesNotDisposeFactoryGeneratedRootSingletonServicesWhenNotInstructedToServicesContainer c = new();
+            var service = Assert.IsType<DisposableServiceImplementation>(c.GetService<IService>());
+
+            c.Dispose();
+
+            Assert.Equal(0, service.DisposalCount);
+        }
+
+        [ServiceProvider]
+        [Singleton(typeof(IService), Factory = nameof(GetService))]
+        internal partial class DisposingProviderDoesNotDisposeFactoryGeneratedRootSingletonServicesWhenNotInstructedToServicesContainer
+        {
+            private static IService GetService() => new DisposableServiceImplementation();
+        }
 
 #if NETCOREAPP
         [Fact]
@@ -620,6 +786,44 @@ namespace JabTests
         [ServiceProvider]
         [Scoped(typeof(IService), typeof(AsyncDisposableServiceImplementation))]
         internal partial class DisposingProviderDisposesRootSingAsyncServicesContainer { }
+
+        [Fact]
+        public async Task DisposingProviderDisposesFactoryGeneratedRootSingAsyncServicesWhenInstructedTo()
+        {
+            DisposingProviderDisposesFactoryGeneratedRootSingAsyncServicesWhenInstructedToServicesContainer c = new();
+            var service = Assert.IsType<AsyncDisposableServiceImplementation>(c.GetService<IService>());
+
+            await c.DisposeAsync();
+
+            Assert.Equal(1, service.AsyncDisposalCount);
+            Assert.Equal(0, service.DisposalCount);
+        }
+
+        [ServiceProvider]
+        [Scoped(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
+        internal partial class DisposingProviderDisposesFactoryGeneratedRootSingAsyncServicesWhenInstructedToServicesContainer
+        {
+            private static IService CreateService() => new AsyncDisposableServiceImplementation();
+        }
+
+        [Fact]
+        public async Task DisposingProviderDoesNotDisposeFactoryGeneratedRootSingAsyncServicesWhenNotInstructedTo()
+        {
+            DisposingProviderDoesNotDisposeFactoryGeneratedRootSingAsyncServicesWhenNotInstructedToServicesContainer c = new();
+            var service = Assert.IsType<AsyncDisposableServiceImplementation>(c.GetService<IService>());
+
+            await c.DisposeAsync();
+
+            Assert.Equal(0, service.AsyncDisposalCount);
+            Assert.Equal(0, service.DisposalCount);
+        }
+
+        [ServiceProvider]
+        [Scoped(typeof(IService), Factory = nameof(CreateService))]
+        internal partial class DisposingProviderDoesNotDisposeFactoryGeneratedRootSingAsyncServicesWhenNotInstructedToServicesContainer
+        {
+            private static IService CreateService() => new AsyncDisposableServiceImplementation();
+        }
 #endif
 
 #if NETCOREAPP
@@ -643,6 +847,55 @@ namespace JabTests
         [Scoped(typeof(IService), typeof(DisposableServiceImplementation))]
         [Scoped(typeof(IService), typeof(DisposableServiceImplementation))]
         internal partial class DisposingProviderDisposesAllSingletonEnumerableServicesContainer { }
+
+        [Fact]
+        public async Task DisposingProviderDisposesAllFactoryGeneratedSingletonEnumerableServicesWhenInstructedTo()
+        {
+            DisposingProviderDisposesAllFactoryGeneratedSingletonEnumerableServicesWhenInstructedToServicesContainer c = new();
+            var services = Assert.IsType<IService[]>(c.GetService<IEnumerable<IService>>());
+
+            await c.DisposeAsync();
+
+            foreach (var service in services)
+            {
+                var disposableService = Assert.IsType<DisposableServiceImplementation>(service);
+                Assert.Equal(1, disposableService.DisposalCount);
+            }
+        }
+
+        [ServiceProvider]
+        [Scoped(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
+        [Scoped(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
+        [Scoped(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
+        internal partial class DisposingProviderDisposesAllFactoryGeneratedSingletonEnumerableServicesWhenInstructedToServicesContainer
+        {
+            private static IService CreateService() => new DisposableServiceImplementation();
+        }
+
+        [Fact]
+        public async Task DisposingProviderDisposesOnlyFactoryGeneratedSingletonEnumerableServicesThatAreRegisteredToDispose()
+        {
+            DisposingProviderDisposesOnlyFactoryGeneratedSingletonEnumerableServicesThatAreRegisteredToDisposeServicesContainer c = new();
+            var services = Assert.IsType<IService[]>(c.GetService<IEnumerable<IService>>());
+
+            await c.DisposeAsync();
+
+            for (int i = 0; i < services.Length; i++)
+            {
+                var disposableService = Assert.IsType<DisposableServiceImplementation>(services[i]);
+                Assert.Equal(i % 2, disposableService.DisposalCount);
+            }
+        }
+
+        [ServiceProvider]
+        [Scoped(typeof(IService), Factory = nameof(CreateService))]
+        [Scoped(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
+        [Scoped(typeof(IService), Factory = nameof(CreateService))]
+        [Scoped(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
+        internal partial class DisposingProviderDisposesOnlyFactoryGeneratedSingletonEnumerableServicesThatAreRegisteredToDisposeServicesContainer
+        {
+            private static IService CreateService() => new DisposableServiceImplementation();
+        }
 #endif
 
         [Fact]
@@ -667,6 +920,58 @@ namespace JabTests
         [ServiceProvider]
         [Transient(typeof(IService), typeof(DisposableServiceImplementation))]
         internal partial class DisposingProviderDisposesTransientsContainer { }
+
+        [Fact]
+        public void DisposingProviderDisposesFactoryGeneratedTransientsIfInstructedTo()
+        {
+            DisposingProviderDisposesFactoryGeneratedTransientsIfInstructedToContainer c = new();
+            List<IService> services = new();
+            for (int i = 0; i < 5; i++)
+            {
+                services.Add(c.GetService<IService>());
+            }
+
+            c.Dispose();
+
+            foreach (var service in services)
+            {
+                var disposableService = Assert.IsType<DisposableServiceImplementation>(service);
+                Assert.Equal(1, disposableService.DisposalCount);
+            }
+        }
+
+        [ServiceProvider]
+        [Transient(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
+        internal partial class DisposingProviderDisposesFactoryGeneratedTransientsIfInstructedToContainer
+        {
+            private static IService CreateService() => new DisposableServiceImplementation();
+        }
+
+        [Fact]
+        public void DisposingProviderDoesNotDisposeFactoryGeneratedTransientsIfNotInstructedTo()
+        {
+            DisposingProviderDoesNotDisposeFactoryGeneratedTransientsIfNotInstructedToContainer c = new();
+            List<IService> services = new();
+            for (int i = 0; i < 5; i++)
+            {
+                services.Add(c.GetService<IService>());
+            }
+
+            c.Dispose();
+
+            foreach (var service in services)
+            {
+                var disposableService = Assert.IsType<DisposableServiceImplementation>(service);
+                Assert.Equal(0, disposableService.DisposalCount);
+            }
+        }
+
+        [ServiceProvider]
+        [Transient(typeof(IService), Factory = nameof(CreateService))]
+        internal partial class DisposingProviderDoesNotDisposeFactoryGeneratedTransientsIfNotInstructedToContainer
+        {
+            private static IService CreateService() => new DisposableServiceImplementation();
+        }
 
         [Fact]
         public void DisposingScopeDisposesTransients()
@@ -694,30 +999,65 @@ namespace JabTests
         internal partial class DisposingScopeDisposesTransientsContainer { }
 
         [Fact]
-        public void DisposingProviderDisposesRootSingletonFactoryServices()
+        public void DisposingScopeDisposesFactoryGeneratedTransientsIfInstructedTo()
         {
-            DisposingProviderDisposesRootSingletonServicesContainer c = new();
-            var service = Assert.IsType<DisposableServiceImplementation>(c.GetService<IService>());
+            DisposingScopeDisposesFactoryGeneratedTransientsIfInstructedToContainer c = new();
+            var scope = c.CreateScope();
 
-            c.Dispose();
-
-            Assert.Equal(1, service.DisposalCount);
-        }
-
-        [ServiceProvider]
-        [Singleton(typeof(IService), Factory = nameof(CreateDisposableServiceImplementation))]
-        internal partial class DisposingProviderDisposesRootSingletonFactoryServicesContainer
-        {
-            internal IService CreateDisposableServiceImplementation()
+            List<IService> services = new();
+            for (int i = 0; i < 5; i++)
             {
-                return new DisposableServiceImplementation();
+                services.Add(scope.GetService<IService>());
+            }
+
+            scope.Dispose();
+
+            foreach (var service in services)
+            {
+                var disposableService = Assert.IsType<DisposableServiceImplementation>(service);
+                Assert.Equal(1, disposableService.DisposalCount);
             }
         }
 
-        [Fact]
-        public void DisposingProviderDoesNotDisposeRootSingletonInstanceServices()
+        [ServiceProvider]
+        [Transient(typeof(IService), Factory = nameof(CreateService), AutoDispose = true)]
+        internal partial class DisposingScopeDisposesFactoryGeneratedTransientsIfInstructedToContainer
         {
-            DisposingProviderDoesNotDisposeRootSingletonInstanceServicesContainer c = new();
+            private IService CreateService() => new DisposableServiceImplementation();
+        }
+
+        [Fact]
+        public void DisposingScopeDoesNotDisposeFactoryGeneratedTransientsIfNotInstructedTo()
+        {
+            DisposingScopeDoesNotDisposeFactoryGeneratedTransientsIfNotInstructedToContainer c = new();
+            var scope = c.CreateScope();
+
+            List<IService> services = new();
+            for (int i = 0; i < 5; i++)
+            {
+                services.Add(scope.GetService<IService>());
+            }
+
+            scope.Dispose();
+
+            foreach (var service in services)
+            {
+                var disposableService = Assert.IsType<DisposableServiceImplementation>(service);
+                Assert.Equal(0, disposableService.DisposalCount);
+            }
+        }
+
+        [ServiceProvider]
+        [Transient(typeof(IService), Factory = nameof(CreateService))]
+        internal partial class DisposingScopeDoesNotDisposeFactoryGeneratedTransientsIfNotInstructedToContainer
+        {
+            private IService CreateService() => new DisposableServiceImplementation();
+        }
+
+        [Fact]
+        public void DisposingProviderDoesNotDisposeRootSingletonInstanceServicesEvenWithAutoDisposeFlagSet()
+        {
+            DisposingProviderDoesNotDisposeRootSingletonInstanceServicesEvenWithAutoDisposeFlagSetContainer c = new();
             var service = Assert.IsType<DisposableServiceImplementation>(c.GetService<IService>());
 
             c.Dispose();
@@ -727,8 +1067,8 @@ namespace JabTests
         }
 
         [ServiceProvider]
-        [Singleton(typeof(IService), Instance = nameof(DisposableServiceImplementation))]
-        internal partial class DisposingProviderDoesNotDisposeRootSingletonInstanceServicesContainer
+        [Singleton(typeof(IService), Instance = nameof(DisposableServiceImplementation), AutoDispose = true)]
+        internal partial class DisposingProviderDoesNotDisposeRootSingletonInstanceServicesEvenWithAutoDisposeFlagSetContainer
         {
             internal DisposableServiceImplementation DisposableServiceImplementation { get; } = new DisposableServiceImplementation();
         }

--- a/src/Jab/Attributes.cs
+++ b/src/Jab/Attributes.cs
@@ -68,6 +68,14 @@ namespace Jab
 
         public string? Factory { get; set; }
 
+        /// <summary>
+        /// If true, the service is considered to be owned by the service provider even though
+        /// it was created by a factory method. The service provider will dispose the service
+        /// automatically when it is disposed. If false, the service provider will not dispose
+        /// the service. The default is false for backwards compatibility reasons.
+        /// </summary>
+        public bool AutoDispose { get; set; }
+
         public SingletonAttribute(Type serviceType)
         {
             ServiceType = serviceType;
@@ -90,11 +98,20 @@ namespace Jab
     class TransientAttribute : Attribute
     {
         public Type ServiceType { get; }
+
         public string? Name { get; set; }
 
         public Type? ImplementationType { get; }
 
         public string? Factory { get; set; }
+
+        /// <summary>
+        /// If true, the service is considered to be owned by the service provider even though
+        /// it was created by a factory method. The service provider will dispose the service
+        /// automatically when it is disposed. If false, the service provider will not dispose
+        /// the service. The default is false for backwards compatibility reasons.
+        /// </summary>
+        public bool AutoDispose { get; set; }
 
         public TransientAttribute(Type serviceType)
         {
@@ -118,11 +135,20 @@ namespace Jab
     class ScopedAttribute : Attribute
     {
         public Type ServiceType { get; }
+
         public string? Name { get; set; }
 
         public Type? ImplementationType { get; }
 
         public string? Factory { get; set; }
+
+        /// <summary>
+        /// If true, the service is considered to be owned by the service provider even though
+        /// it was created by a factory method. The service provider will dispose the service
+        /// automatically when it is disposed. If false, the service provider will not dispose
+        /// the service. The default is false for backwards compatibility reasons.
+        /// </summary>
+        public bool AutoDispose { get; set; }
 
         public ScopedAttribute(Type serviceType)
         {

--- a/src/Jab/Attributes.cs
+++ b/src/Jab/Attributes.cs
@@ -68,14 +68,6 @@ namespace Jab
 
         public string? Factory { get; set; }
 
-        /// <summary>
-        /// If true, the service is considered to be owned by the service provider even though
-        /// it was created by a factory method. The service provider will dispose the service
-        /// automatically when it is disposed. If false, the service provider will not dispose
-        /// the service. The default is false for backwards compatibility reasons.
-        /// </summary>
-        public bool AutoDispose { get; set; }
-
         public SingletonAttribute(Type serviceType)
         {
             ServiceType = serviceType;
@@ -105,14 +97,6 @@ namespace Jab
 
         public string? Factory { get; set; }
 
-        /// <summary>
-        /// If true, the service is considered to be owned by the service provider even though
-        /// it was created by a factory method. The service provider will dispose the service
-        /// automatically when it is disposed. If false, the service provider will not dispose
-        /// the service. The default is false for backwards compatibility reasons.
-        /// </summary>
-        public bool AutoDispose { get; set; }
-
         public TransientAttribute(Type serviceType)
         {
             ServiceType = serviceType;
@@ -141,14 +125,6 @@ namespace Jab
         public Type? ImplementationType { get; }
 
         public string? Factory { get; set; }
-
-        /// <summary>
-        /// If true, the service is considered to be owned by the service provider even though
-        /// it was created by a factory method. The service provider will dispose the service
-        /// automatically when it is disposed. If false, the service provider will not dispose
-        /// the service. The default is false for backwards compatibility reasons.
-        /// </summary>
-        public bool AutoDispose { get; set; }
 
         public ScopedAttribute(Type serviceType)
         {

--- a/src/Jab/KnownTypes.cs
+++ b/src/Jab/KnownTypes.cs
@@ -43,7 +43,6 @@ internal class KnownTypes
     public const string InstanceAttributePropertyName = "Instance";
     public const string FactoryAttributePropertyName = "Factory";
     public const string RootServicesAttributePropertyName = "RootServices";
-    public const string AutoDisposeAttributePropertyName = "AutoDispose";
 
     private const string IAsyncDisposableMetadataName = "System.IAsyncDisposable";
     private const string IEnumerableMetadataName = "System.Collections.Generic.IEnumerable`1";

--- a/src/Jab/KnownTypes.cs
+++ b/src/Jab/KnownTypes.cs
@@ -43,6 +43,7 @@ internal class KnownTypes
     public const string InstanceAttributePropertyName = "Instance";
     public const string FactoryAttributePropertyName = "Factory";
     public const string RootServicesAttributePropertyName = "RootServices";
+    public const string AutoDisposeAttributePropertyName = "AutoDispose";
 
     private const string IAsyncDisposableMetadataName = "System.IAsyncDisposable";
     private const string IEnumerableMetadataName = "System.Collections.Generic.IEnumerable`1";

--- a/src/Jab/ServiceProviderBuilder.cs
+++ b/src/Jab/ServiceProviderBuilder.cs
@@ -336,7 +336,8 @@ internal class ServiceProviderBuilder
                     registration.Location,
                     memberLocation: registration.MemberLocation,
                     factoryMember: constructedFactoryMethod,
-                    context: context);
+                    context: context,
+                    autoDispose: registration.AutoDispose);
             }
             else if (registration.ImplementationType != null)
             {
@@ -489,7 +490,8 @@ internal class ServiceProviderBuilder
                     registration.Location,
                     registration.MemberLocation,
                     factoryMember,
-                    context);
+                    context,
+                    registration.AutoDispose);
             }
             else
             {
@@ -513,7 +515,8 @@ internal class ServiceProviderBuilder
         Location? registrationLocation,
         MemberLocation memberLocation,
         ISymbol factoryMember,
-        ServiceResolutionContext context)
+        ServiceResolutionContext context,
+        bool autoDispose)
     {
         ImmutableArray<IParameterSymbol> GetDelegateParameters(ITypeSymbol type)
         {
@@ -571,7 +574,7 @@ internal class ServiceProviderBuilder
             parameters.ToArray(),
             namedParameters.ToArray(),
             lifetime,
-            false);
+            autoDispose);
 
         return factoryCallSite;
     }
@@ -974,6 +977,7 @@ internal class ServiceProviderBuilder
         string? registrationName = null;
         string? instanceMemberName = null;
         string? factoryMemberName = null;
+        var autoDispose = false;
         foreach (var namedArgument in attributeData.NamedArguments)
         {
             switch (namedArgument.Key)
@@ -987,6 +991,9 @@ internal class ServiceProviderBuilder
                     break;
                 case KnownTypes.FactoryAttributePropertyName:
                     factoryMemberName = (string?)namedArgument.Value.Value;
+                    break;
+                case KnownTypes.AutoDisposeAttributePropertyName:
+                    autoDispose = namedArgument.Value.Value is true;
                     break;
             }
         }
@@ -1055,7 +1062,8 @@ internal class ServiceProviderBuilder
             instanceMember,
             factoryMember,
             attributeData.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
-            memberLocation);
+            memberLocation,
+            autoDispose);
 
         return true;
     }

--- a/src/Jab/ServiceProviderBuilder.cs
+++ b/src/Jab/ServiceProviderBuilder.cs
@@ -329,15 +329,14 @@ internal class ServiceProviderBuilder
             {
                 var constructedFactoryMethod = factoryMethod.ConstructedFrom.Construct(genericType.TypeArguments,
                     genericType.TypeArgumentNullableAnnotations);
-                callSite =  CreateFactoryCallSite(
+                callSite = CreateFactoryCallSite(
                     identity,
                     genericType,
                     registration.Lifetime,
                     registration.Location,
                     memberLocation: registration.MemberLocation,
                     factoryMember: constructedFactoryMethod,
-                    context: context,
-                    autoDispose: registration.AutoDispose);
+                    context: context);
             }
             else if (registration.ImplementationType != null)
             {
@@ -490,8 +489,7 @@ internal class ServiceProviderBuilder
                     registration.Location,
                     registration.MemberLocation,
                     factoryMember,
-                    context,
-                    registration.AutoDispose);
+                    context);
             }
             else
             {
@@ -515,8 +513,7 @@ internal class ServiceProviderBuilder
         Location? registrationLocation,
         MemberLocation memberLocation,
         ISymbol factoryMember,
-        ServiceResolutionContext context,
-        bool autoDispose)
+        ServiceResolutionContext context)
     {
         ImmutableArray<IParameterSymbol> GetDelegateParameters(ITypeSymbol type)
         {
@@ -574,7 +571,7 @@ internal class ServiceProviderBuilder
             parameters.ToArray(),
             namedParameters.ToArray(),
             lifetime,
-            autoDispose);
+            true);
 
         return factoryCallSite;
     }
@@ -977,7 +974,6 @@ internal class ServiceProviderBuilder
         string? registrationName = null;
         string? instanceMemberName = null;
         string? factoryMemberName = null;
-        var autoDispose = false;
         foreach (var namedArgument in attributeData.NamedArguments)
         {
             switch (namedArgument.Key)
@@ -991,9 +987,6 @@ internal class ServiceProviderBuilder
                     break;
                 case KnownTypes.FactoryAttributePropertyName:
                     factoryMemberName = (string?)namedArgument.Value.Value;
-                    break;
-                case KnownTypes.AutoDisposeAttributePropertyName:
-                    autoDispose = namedArgument.Value.Value is true;
                     break;
             }
         }
@@ -1062,8 +1055,7 @@ internal class ServiceProviderBuilder
             instanceMember,
             factoryMember,
             attributeData.ApplicationSyntaxReference?.GetSyntax().GetLocation(),
-            memberLocation,
-            autoDispose);
+            memberLocation);
 
         return true;
     }

--- a/src/Jab/ServiceRegistration.cs
+++ b/src/Jab/ServiceRegistration.cs
@@ -8,16 +8,7 @@ internal record ServiceRegistration(
     ISymbol? InstanceMember,
     ISymbol? FactoryMember,
     Location? Location,
-    MemberLocation MemberLocation)
-{
-    public INamedTypeSymbol ServiceType { get; } = ServiceType;
-    public string? Name { get; } = Name;
-    public INamedTypeSymbol? ImplementationType { get; } = ImplementationType;
-    public ISymbol? InstanceMember { get; } = InstanceMember;
-    public ISymbol? FactoryMember { get; } = FactoryMember;
-    public ServiceLifetime Lifetime { get; } = Lifetime;
-    public Location? Location { get; } = Location;
-    public MemberLocation MemberLocation { get; } = MemberLocation;
-}
+    MemberLocation MemberLocation,
+    bool AutoDispose);
 
 internal record RootService(INamedTypeSymbol Service, Location? Location);

--- a/src/Jab/ServiceRegistration.cs
+++ b/src/Jab/ServiceRegistration.cs
@@ -8,7 +8,6 @@ internal record ServiceRegistration(
     ISymbol? InstanceMember,
     ISymbol? FactoryMember,
     Location? Location,
-    MemberLocation MemberLocation,
-    bool AutoDispose);
+    MemberLocation MemberLocation);
 
 internal record RootService(INamedTypeSymbol Service, Location? Location);


### PR DESCRIPTION
This PR adds the capability to auto-dispose factory generated services. I found that there was a broken test that indicates that disposing factory generated services was indended but was not properly implemented (the test was flawed). This PR adds a flag that allows users to opt into automatic dispose of factory generated services.

This functionality could be improved by erroring out when the AutoDispose flag is used other than for factory generated services.

This PR also updates the CI/CD pipeline to work

This PR drops netcoreapp3.1, as I got test failures with this framework that has long been deprecated by microsoft and thus it seemed useless to investigate in the reason for the failures.

Fixes #178 