### PR TITLE
Add support for .NET 9

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,9 +15,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           3.1.x
@@ -44,7 +44,7 @@ jobs:
         npm version ${{ steps.vars.outputs.PackageVersion }} --allow-same-version
         npm pack --pack-destination=../../nuget
     - name: 'Upload Artifact'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: nuget
         path: nuget/
@@ -69,14 +69,14 @@ jobs:
             tfm: net8.0
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: nuget
         path: nuget
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.sdk }}
     - name: Get package version
@@ -95,12 +95,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: nuget
         path: nuget
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.x
     - name: Publish unity packages to npm
@@ -118,12 +118,12 @@ jobs:
     needs: [build, publish]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Update package versions in the repo
         shell: pwsh
         run: ./eng/UpdateAllVersions.ps1 ${{ needs.build.outputs.PackageVersion }} ${{ github.workspace }}
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           title: Update sample versions
           branch: update-versions

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
@@ -24,6 +24,7 @@ jobs:
           6.0.x
           7.0.x
           8.0.x
+          9.0.x
     - name: Build
       run: dotnet build src
     - name: Test
@@ -56,18 +57,19 @@ jobs:
       matrix:
         sdk: 
           - 6.0.x
-          - 7.x
-          - 8.x
-        # https://github.com/microsoft/MSBuildSdks/issues/412
-        # sdk: [6.0.x, 7.0.x]
+          - 7.0.x
+          - 8.0.x
+          - 9.0.x
         include:
           - sdk: 6.0.x
             tfm: net6.0
-          - sdk: 7.x
+          - sdk: 7.0.x
             tfm: net7.0
-          - sdk: 8.x
+          - sdk: 8.0.x
             tfm: net8.0
-    runs-on: ubuntu-latest
+          - sdk: 9.0.x
+            tfm: net9.0
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Download all workflow run artifacts
@@ -92,7 +94,7 @@ jobs:
   publish:
     if: (github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     needs: [build, test]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Download all workflow run artifacts
       uses: actions/download-artifact@v4
@@ -116,7 +118,7 @@ jobs:
 
   update_versions:
     needs: [build, publish]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Update package versions in the repo

--- a/src/Jab.FunctionalTests.Common/Jab.FunctionalTest.props
+++ b/src/Jab.FunctionalTests.Common/Jab.FunctionalTest.props
@@ -1,7 +1,7 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <DefaultFunctionalTestTargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0;netstandard2.0</DefaultFunctionalTestTargetFrameworks>
+    <DefaultFunctionalTestTargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0;net9.0;netstandard2.0</DefaultFunctionalTestTargetFrameworks>
     <DefaultFunctionalTestTargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))" >$(DefaultFunctionalTestTargetFrameworks);net472</DefaultFunctionalTestTargetFrameworks>
     <FunctionalTestTargetFrameworks Condition="'$(FunctionalTestTargetFrameworks)' == ''">$(DefaultFunctionalTestTargetFrameworks)</FunctionalTestTargetFrameworks>
     <IsPackable>false</IsPackable>

--- a/src/Jab.FunctionalTests.MEDI/Jab.FunctionalTests.MEDI.csproj
+++ b/src/Jab.FunctionalTests.MEDI/Jab.FunctionalTests.MEDI.csproj
@@ -13,5 +13,6 @@
     <PackageReference Condition="'$(TargetFramework)' == 'net6.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0"/>
     <PackageReference Condition="'$(TargetFramework)' == 'net7.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
     <PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0"/>
+    <PackageReference Condition="'$(TargetFramework)' == 'net9.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0"/>
   </ItemGroup>
 </Project>

--- a/src/Jab.Tests/Jab.Tests.csproj
+++ b/src/Jab.Tests/Jab.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Updating all GitHub Actions to v4 versions
- Add support for .NET 9 to the relevant projects and GitHub Action YAML
- Pin the runner to `ubuntu-22.04` as .NET Core 3 has issues with ICU on `ubuntu-24.04` (see also #148 )